### PR TITLE
Connect web invite page to API

### DIFF
--- a/Web/lib/config.js
+++ b/Web/lib/config.js
@@ -1,0 +1,2 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";


### PR DESCRIPTION
## Summary
- add configurable API base URL
- fetch invite tokens from backend API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c363f9bd48330bba3428ad6917acb