### PR TITLE
Add Python-based Dockerfile for API deployment

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# نصب وابستگی‌ها
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# کد پروژه
+COPY . .
+
+# Railway پورت را در محیط می‌دهد
+ENV PORT=8000
+EXPOSE 8000
+
+CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Summary
- provide a Dockerfile using Python 3.11 for the API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18b530164833083d77cc53f787f23